### PR TITLE
Show expected_quantity for unsaved lines.

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -37,7 +37,7 @@ class InventoryLine(metaclass=PoolMeta):
                 inactive_lots=True):
             if Lot and lot:
                 pbl = Product.products_by_location(
-                    [inventory.location.id], grouping_filter=[[product], 
+                    [inventory.location.id], grouping_filter=[[product],
                     [lot]], grouping=('product', 'lot'))
                 return pbl[(inventory.location.id, product, lot)]
             pbl = Product.products_by_location(

--- a/inventory.py
+++ b/inventory.py
@@ -54,7 +54,7 @@ class InventoryLine(metaclass=PoolMeta):
         return self._compute_expected_quantity(
             self.inventory,
             self.product.id if self.product else None,
-            lot.id if self.lot else None)
+            lot.id if lot else None)
 
     @classmethod
     def create(cls, vlist):

--- a/inventory.py
+++ b/inventory.py
@@ -10,6 +10,11 @@ __all__ = ['InventoryLine']
 class InventoryLine(metaclass=PoolMeta):
     __name__ = 'stock.inventory.line'
 
+    @classmethod
+    def __setup__(cls):
+        super().__setup__()
+        cls.expected_quantity.states['invisible'] = False
+
     @staticmethod
     def _compute_expected_quantity(inventory, product, lot=None):
         pool = Pool()


### PR DESCRIPTION
The visibility constraint was intoduced by
https://bugs.tryton.org/issue6976
https://github.com/tryton/stock/commit/65c705dda00e71162de65b9f4ffa4babd2444f2d

This patch enables the user to see the expected quantity as soon as they
have entered a product which is the expectation from the user's point of
view.